### PR TITLE
[DEVAI-190] Use placeholder username for owner entries in examples

### DIFF
--- a/developer-model-service/catalog-info.yaml
+++ b/developer-model-service/catalog-info.yaml
@@ -29,7 +29,7 @@ metadata:
     - gateway
 spec:
   type: model-server
-  owner: user:jcollier
+  owner: user:someuser
   lifecycle: production
   providesApis:
     - model-service-api
@@ -80,7 +80,7 @@ metadata:
     - task-text-generation
 spec:
   type: ai-model
-  owner: user:jcollier
+  owner: user:jsomeuser
   lifecycle: production
   providesApis:
     - model-service-api
@@ -106,7 +106,7 @@ metadata:
       icon: WebAsset
 spec:
   type: openapi
-  owner: user:jcollier
+  owner: user:jsomeuser
   lifecycle: production
   dependencyOf: 
     - component:ibm-granite-8b-code-instruct

--- a/ollama-model-service/catalog-info.yaml
+++ b/ollama-model-service/catalog-info.yaml
@@ -30,7 +30,7 @@ metadata:
     - ollama-model-service
 spec:
   type: model-server
-  owner: user:jcollier
+  owner: user:jsomeuser
   lifecycle: production
   providesApis:
     - ollama-service-api
@@ -81,7 +81,7 @@ metadata:
     - 20b
 spec:
   type: ai-model
-  owner: user:jcollier
+  owner: user:jsomeuser
   lifecycle: production
   providesApis:
     - ollama-service-api
@@ -125,7 +125,7 @@ metadata:
     - 1b
 spec:
   type: ai-model
-  owner: user:jcollier
+  owner: user:jsomeuser
   lifecycle: production
   providesApis:
     - ollama-service-api
@@ -168,7 +168,7 @@ metadata:
     - 2b
 spec:
   type: ai-model
-  owner: user:jcollier
+  owner: user:jsomeuser
   lifecycle: production
   providesApis:
     - ollama-service-api
@@ -209,7 +209,7 @@ metadata:
     - task-text-generation
 spec:
   type: ai-model
-  owner: user:jcollier
+  owner: user:jsomeuser
   lifecycle: production
   providesApis:
     - ollama-service-api
@@ -239,7 +239,7 @@ metadata:
       icon: WebAsset
 spec:
   type: openapi
-  owner: user:jcollier
+  owner: user:jsomeuser
   lifecycle: production
   dependencyOf: 
     - component:ollama-model-service


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/DEVAI-190

This PR updates all of the catalog entities to user a placeholder username in the `spec.owner` field. I also did a cursory overview and didn't see any other fields needing updating.